### PR TITLE
feat: download-ruby-code

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -90,6 +90,7 @@ import smalrubyLogo from './hatti.svg';
 import {updateRubyCodeTarget} from '../../reducers/ruby-code';
 
 import sharedMessages from '../../lib/shared-messages';
+import RubyDownloader from '../../containers/ruby-downloader.jsx';
 
 const ariaMessages = defineMessages({
     tutorials: {
@@ -496,6 +497,18 @@ class MenuBar extends React.Component {
                                                 />
                                             </MenuItem>
                                         )}</SB3Downloader>
+                                        <RubyDownloader>{(className, downloadProjectCallback) => (
+                                            <MenuItem
+                                            className={className}
+                                            onClick={this.getSaveToComputerHandler(downloadProjectCallback)}
+                                            >
+                                                <FormattedMessage
+                                                    defaultMessage="Download Ruby code to your compute"
+                                                    description="Menu bar item for downloading Ruby code to your computer"
+                                                    id="gui.smalruby3.menuBar.downloadRubyCodeToComputer"
+                                                />
+                                            </MenuItem>
+                                        )}</RubyDownloader>
                                     </MenuSection>
                                 </MenuBarMenu>
                             </div>


### PR DESCRIPTION
# やること
Rubyをダウンロード可能にする

# 方法
今のメニューからではなくRubyタブを開いた時のみ専用のボタンを表示して、そのボタンからダウンロードできるようにした